### PR TITLE
Update the basholeveldb fork with the latest commits from jmhodges/levigo

### DIFF
--- a/basholeveldb/README.md
+++ b/basholeveldb/README.md
@@ -13,7 +13,7 @@ You'll need the shared library build of
 [LevelDB](http://code.google.com/p/leveldb/) installed on your machine. The
 current LevelDB will build it by default.
 
-The minimum version of LevelDB required is currently 1.6. If you require the
+The minimum version of LevelDB required is currently 1.7. If you require the
 use of an older version of LevelDB, see the [fork of levigo for LevelDB
 1.4](https://github.com/jmhodges/levigo_leveldb_1.4). Prefer putting in the
 work to be up to date as LevelDB moves very quickly.

--- a/basholeveldb/README.md
+++ b/basholeveldb/README.md
@@ -1,3 +1,5 @@
+[![GoDoc](https://godoc.org/github.com/janelia-flyem/go/basholeveldb?status.svg)](https://godoc.org/github.com/janelia-flyem/go/basholeveldb)
+
 # levigo
 
 levigo is a Go wrapper for LevelDB.

--- a/basholeveldb/batch.go
+++ b/basholeveldb/batch.go
@@ -1,6 +1,6 @@
 package levigo
 
-// #cgo LDFLAGS: -lleveldb
+// #cgo LDFLAGS: -lleveldb -lstdc++
 // #include "leveldb/c.h"
 import "C"
 

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -29,10 +29,11 @@ import (
 	"unsafe"
 )
 
+// DatabaseError wraps general internal LevelDB errors for user consumption.
 type DatabaseError string
 
 func (e DatabaseError) Error() string {
-	return string(e)
+	return "levigo: " + string(e)
 }
 
 var ErrDBClosed = errors.New("database is closed")

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -54,8 +54,10 @@ type Range struct {
 	Limit []byte
 }
 
-// Snapshot provides a consistent view of read operations in a DB. It is set
-// on to a ReadOptions and passed in. It is only created by DB.NewSnapshot.
+// Snapshot provides a consistent view of read operations in a DB.
+//
+// Snapshot is used in read operations by setting it on a
+// ReadOptions. Snapshots are created by calling DB.NewSnapshot.
 //
 // To prevent memory leaks and resource strain in the database, the snapshot
 // returned must be released with DB.ReleaseSnapshot method on the DB that
@@ -120,8 +122,9 @@ func RepairDatabase(dbname string, o *Options) error {
 
 // Put writes data associated with a key to the database.
 //
-// If a nil []byte is passed in as value, it will be returned by Get as an
-// zero-length slice.
+// If a nil []byte is passed in as value, it will be returned by Get
+// as an zero-length slice. The WriteOptions passed in can be reused
+// by multiple calls to this and if the WriteOptions is left unchanged.
 //
 // The key and value byte slices may be reused safely. Put takes a copy of
 // them before returning.
@@ -187,7 +190,8 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 // Delete removes the data associated with the key from the database.
 //
 // The key byte slice may be reused safely. Delete takes a copy of
-// them before returning.
+// them before returning. The WriteOptions passed in can be reused by
+// multiple calls to this and if the WriteOptions is left unchanged.
 func (db *DB) Delete(wo *WriteOptions, key []byte) error {
 	var errStr *C.char
 	var k *C.char
@@ -206,7 +210,8 @@ func (db *DB) Delete(wo *WriteOptions, key []byte) error {
 	return nil
 }
 
-// Write atomically writes a WriteBatch to disk.
+// Write atomically writes a WriteBatch to disk. The WriteOptions
+// passed in can be reused by multiple calls to this and other methods.
 func (db *DB) Write(wo *WriteOptions, w *WriteBatch) error {
 	var errStr *C.char
 	C.leveldb_write(db.Ldb, wo.Opt, w.wbatch, &errStr)
@@ -228,6 +233,9 @@ func (db *DB) Write(wo *WriteOptions, w *WriteBatch) error {
 // before passing it here.
 //
 // Similiarly, ReadOptions.SetSnapshot is also useful.
+//
+// The ReadOptions passed in can be reused by multiple calls to this
+// and other methods if the ReadOptions is left unchanged.
 func (db *DB) NewIterator(ro *ReadOptions) *Iterator {
 	it := C.leveldb_create_iterator(db.Ldb, ro.Opt)
 	return &Iterator{Iter: it}
@@ -279,8 +287,8 @@ func (db *DB) PropertyValue(propName string) string {
 
 // NewSnapshot creates a new snapshot of the database.
 //
-// The snapshot, when used in a ReadOptions, provides a consistent view of
-// state of the database at the the snapshot was created.
+// The Snapshot, when used in a ReadOptions, provides a consistent
+// view of state of the database at the the snapshot was created.
 //
 // To prevent memory leaks and resource strain in the database, the snapshot
 // returned must be released with DB.ReleaseSnapshot method on the DB that

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -35,7 +35,7 @@ func (e DatabaseError) Error() string {
 	return string(e)
 }
 
-const ErrDBClosed = errors.New("database is closed")
+var ErrDBClosed = errors.New("database is closed")
 
 // DB is a reusable handle to a LevelDB database on disk, created by Open.
 //

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -36,6 +36,7 @@ func (e DatabaseError) Error() string {
 	return "levigo: " + string(e)
 }
 
+// ErrDBClosed is returned by DB.Close when its been called previously.
 var ErrDBClosed = errors.New("database is closed")
 
 // DB is a reusable handle to a LevelDB database on disk, created by Open.

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -232,7 +232,7 @@ func (db *DB) Write(wo *WriteOptions, w *WriteBatch) error {
 // data. This can be done by calling SetFillCache(false) on the ReadOptions
 // before passing it here.
 //
-// Similiarly, ReadOptions.SetSnapshot is also useful.
+// Similarly, ReadOptions.SetSnapshot is also useful.
 //
 // The ReadOptions passed in can be reused by multiple calls to this
 // and other methods if the ReadOptions is left unchanged.

--- a/basholeveldb/db.go
+++ b/basholeveldb/db.go
@@ -25,6 +25,7 @@ void levigo_leveldb_approximate_sizes(
 import "C"
 
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -33,6 +34,8 @@ type DatabaseError string
 func (e DatabaseError) Error() string {
 	return string(e)
 }
+
+const ErrDBClosed = errors.New("database is closed")
 
 // DB is a reusable handle to a LevelDB database on disk, created by Open.
 //
@@ -45,6 +48,8 @@ func (e DatabaseError) Error() string {
 // course.
 type DB struct {
 	Ldb *C.leveldb_t
+
+	closed bool
 }
 
 // Range is a range of keys in the database. GetApproximateSizes calls with it
@@ -84,7 +89,7 @@ func Open(dbname string, o *Options) (*DB, error) {
 		C.free(unsafe.Pointer(errStr))
 		return nil, DatabaseError(gs)
 	}
-	return &DB{leveldb}, nil
+	return &DB{leveldb, false}, nil
 }
 
 // DestroyDatabase removes a database entirely, removing everything from the
@@ -129,6 +134,10 @@ func RepairDatabase(dbname string, o *Options) error {
 // The key and value byte slices may be reused safely. Put takes a copy of
 // them before returning.
 func (db *DB) Put(wo *WriteOptions, key, value []byte) error {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	var errStr *C.char
 	// leveldb_put, _get, and _delete call memcpy() (by way of Memtable::Add)
 	// when called, so we do not need to worry about these []byte being
@@ -163,6 +172,10 @@ func (db *DB) Put(wo *WriteOptions, key, value []byte) error {
 // The key byte slice may be reused safely. Get takes a copy of
 // them before returning.
 func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	var errStr *C.char
 	var vallen C.size_t
 	var k *C.char
@@ -193,6 +206,10 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 // them before returning. The WriteOptions passed in can be reused by
 // multiple calls to this and if the WriteOptions is left unchanged.
 func (db *DB) Delete(wo *WriteOptions, key []byte) error {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	var errStr *C.char
 	var k *C.char
 	if len(key) != 0 {
@@ -213,6 +230,10 @@ func (db *DB) Delete(wo *WriteOptions, key []byte) error {
 // Write atomically writes a WriteBatch to disk. The WriteOptions
 // passed in can be reused by multiple calls to this and other methods.
 func (db *DB) Write(wo *WriteOptions, w *WriteBatch) error {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	var errStr *C.char
 	C.leveldb_write(db.Ldb, wo.Opt, w.wbatch, &errStr)
 	if errStr != nil {
@@ -237,6 +258,10 @@ func (db *DB) Write(wo *WriteOptions, w *WriteBatch) error {
 // The ReadOptions passed in can be reused by multiple calls to this
 // and other methods if the ReadOptions is left unchanged.
 func (db *DB) NewIterator(ro *ReadOptions) *Iterator {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	it := C.leveldb_create_iterator(db.Ldb, ro.Opt)
 	return &Iterator{Iter: it}
 }
@@ -279,6 +304,10 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 // Examples of properties include "leveldb.stats", "leveldb.sstables",
 // and "leveldb.num-files-at-level0".
 func (db *DB) PropertyValue(propName string) string {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	cname := C.CString(propName)
 	value := C.GoString(C.leveldb_property_value(db.Ldb, cname))
 	C.free(unsafe.Pointer(cname))
@@ -296,18 +325,30 @@ func (db *DB) PropertyValue(propName string) string {
 //
 // See the LevelDB documentation for details.
 func (db *DB) NewSnapshot() *Snapshot {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	return &Snapshot{C.leveldb_create_snapshot(db.Ldb)}
 }
 
 // ReleaseSnapshot removes the snapshot from the database's list of snapshots,
 // and deallocates it.
 func (db *DB) ReleaseSnapshot(snap *Snapshot) {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	C.leveldb_release_snapshot(db.Ldb, snap.snap)
 }
 
 // CompactRange runs a manual compaction on the Range of keys given. This is
 // not likely to be needed for typical usage.
 func (db *DB) CompactRange(r Range) {
+	if db.closed {
+		panic(ErrDBClosed)
+	}
+
 	var start, limit *C.char
 	if len(r.Start) != 0 {
 		start = (*C.char)(unsafe.Pointer(&r.Start[0]))
@@ -324,5 +365,10 @@ func (db *DB) CompactRange(r Range) {
 //
 // Any attempts to use the DB after Close is called will panic.
 func (db *DB) Close() {
+	if db.closed {
+		return
+	}
+
+	db.closed = true
 	C.leveldb_close(db.Ldb)
 }

--- a/basholeveldb/doc.go
+++ b/basholeveldb/doc.go
@@ -30,7 +30,8 @@ ReadOptions you use when creating the Iterator.
 	it := db.NewIterator(ro)
 	defer it.Close()
 	it.Seek(mykey)
-	for it = it; it.Valid(); it.Next() {
+	for it.Valid() {
+		it.Next()
 		munge(it.Key(), it.Value())
 	}
 	if err := it.GetError(); err != nil {

--- a/basholeveldb/doc.go
+++ b/basholeveldb/doc.go
@@ -29,9 +29,7 @@ ReadOptions you use when creating the Iterator.
 	ro.SetFillCache(false)
 	it := db.NewIterator(ro)
 	defer it.Close()
-	it.Seek(mykey)
-	for it.Valid() {
-		it.Next()
+	for it.Seek(mykey); it.Valid(); it.Next() {
 		munge(it.Key(), it.Value())
 	}
 	if err := it.GetError(); err != nil {

--- a/basholeveldb/filterpolicy.go
+++ b/basholeveldb/filterpolicy.go
@@ -27,6 +27,7 @@ func NewBloomFilter(bitsPerKey int) *FilterPolicy {
 	return &FilterPolicy{policy}
 }
 
+// Close reaps the resources associated with this FilterPolicy.
 func (fp *FilterPolicy) Close() {
 	C.leveldb_filterpolicy_destroy(fp.Policy)
 }

--- a/basholeveldb/go.mod
+++ b/basholeveldb/go.mod
@@ -1,0 +1,1 @@
+module github.com/janelia-flyem/go/basholeveldb

--- a/basholeveldb/iterator.go
+++ b/basholeveldb/iterator.go
@@ -35,7 +35,8 @@ func (e IteratorError) Error() string {
 // 	it := db.NewIterator(readOpts)
 // 	defer it.Close()
 // 	it.Seek(mykey)
-// 	for it = it; it.Valid(); it.Next() {
+// 	for it.Valid() {
+// 		it.Next()
 // 		useKeyAndValue(it.Key(), it.Value())
 // 	}
 // 	if err := it.GetError() {

--- a/basholeveldb/iterator.go
+++ b/basholeveldb/iterator.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 )
 
+// IteratorError wraps general internal LevelDB iterator errors for user consumption.
 type IteratorError string
 
 func (e IteratorError) Error() string {

--- a/basholeveldb/iterator.go
+++ b/basholeveldb/iterator.go
@@ -12,7 +12,7 @@ import (
 type IteratorError string
 
 func (e IteratorError) Error() string {
-	return string(e)
+	return "levigo: " + string(e)
 }
 
 // Iterator is a read-only iterator through a LevelDB database. It provides a

--- a/basholeveldb/iterator.go
+++ b/basholeveldb/iterator.go
@@ -34,9 +34,7 @@ func (e IteratorError) Error() string {
 //
 // 	it := db.NewIterator(readOpts)
 // 	defer it.Close()
-// 	it.Seek(mykey)
-// 	for it.Valid() {
-// 		it.Next()
+// 	for it.Seek(mykey); it.Valid(); it.Next() {
 // 		useKeyAndValue(it.Key(), it.Value())
 // 	}
 // 	if err := it.GetError() {

--- a/basholeveldb/leveldb_test.go
+++ b/basholeveldb/leveldb_test.go
@@ -117,7 +117,6 @@ func TestC(t *testing.T) {
 
 	// approximate sizes
 	n := 20000
-	woptions.SetSync(false)
 	for i := 0; i < n; i++ {
 		keybuf := []byte(fmt.Sprintf("k%020d", i))
 		valbuf := []byte(fmt.Sprintf("v%020d", i))

--- a/basholeveldb/leveldb_test.go
+++ b/basholeveldb/leveldb_test.go
@@ -16,6 +16,10 @@ func init() {
 
 // This testcase is a port of leveldb's c_test.c.
 func TestC(t *testing.T) {
+	if GetLevelDBMajorVersion() <= 0 {
+		t.Errorf("Major version cannot be less than zero")
+	}
+
 	dbname := tempDir(t)
 	defer deleteDBDirectory(t, dbname)
 	env := NewDefaultEnv()

--- a/basholeveldb/leveldb_test.go
+++ b/basholeveldb/leveldb_test.go
@@ -228,6 +228,7 @@ func TestNilSlicesInDb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Database could not be opened: %v", err)
 	}
+	defer db.Close()
 	val, err := db.Get(ro, []byte("missing"))
 	if err != nil {
 		t.Errorf("Get failed: %v", err)

--- a/basholeveldb/options.go
+++ b/basholeveldb/options.go
@@ -78,10 +78,10 @@ func (o *Options) SetComparator(cmp *C.leveldb_comparator_t) {
 	C.leveldb_options_set_comparator(o.Opt, cmp)
 }
 
-// SetErrorIfExists, if passed true, will cause the opening of a database that
-// already exists to throw an error.
-func (o *Options) SetErrorIfExists(error_if_exists bool) {
-	eie := boolToUchar(error_if_exists)
+// SetErrorIfExists causes the opening of a database that already exists to
+// throw an error if true.
+func (o *Options) SetErrorIfExists(errorIfExists bool) {
+	eie := boolToUchar(errorIfExists)
 	C.leveldb_options_set_error_if_exists(o.Opt, eie)
 }
 
@@ -110,9 +110,8 @@ func (o *Options) SetWriteBufferSize(s int) {
 	C.leveldb_options_set_write_buffer_size(o.Opt, C.size_t(s))
 }
 
-// SetParanoidChecks, when called with true, will cause the database to do
-// aggressive checking of the data it is processing and will stop early if it
-// detects errors.
+// SetParanoidChecks causes the database to do aggressive checking of the data
+// it is processing and will stop early if it detects errors if true.
 //
 // See the LevelDB documentation docs for details.
 func (o *Options) SetParanoidChecks(pc bool) {

--- a/basholeveldb/options.go
+++ b/basholeveldb/options.go
@@ -34,7 +34,7 @@ type ReadOptions struct {
 	Opt *C.leveldb_readoptions_t
 }
 
-// WriteOptions represent all of the available options when writeing from a
+// WriteOptions represent all of the available options when writing from a
 // database.
 //
 // To prevent memory leaks, Close must called on a WriteOptions when the
@@ -219,7 +219,7 @@ func (wo *WriteOptions) Close() {
 // be flushed from the operating system buffer cache before the write is
 // considered complete.
 //
-// If called with true, this will signficantly slow down writes. If called
+// If called with true, this will significantly slow down writes. If called
 // with false, and the host machine crashes, some recent writes may be
 // lost. The default is false.
 //

--- a/basholeveldb/version.go
+++ b/basholeveldb/version.go
@@ -1,0 +1,15 @@
+package levigo
+
+/*
+#cgo LDFLAGS: -lleveldb
+#include "leveldb/c.h"
+*/
+import "C"
+
+func GetLevelDBMajorVersion() int {
+	return int(C.leveldb_major_version())
+}
+
+func GetLevelDBMinorVersion() int {
+	return int(C.leveldb_minor_version())
+}

--- a/basholeveldb/version.go
+++ b/basholeveldb/version.go
@@ -6,10 +6,14 @@ package levigo
 */
 import "C"
 
+// GetLevelDBMajorVersion returns the underlying LevelDB implementation's major
+// version.
 func GetLevelDBMajorVersion() int {
 	return int(C.leveldb_major_version())
 }
 
+// GetLevelDBMinorVersion returns the underlying LevelDB implementation's minor
+// version.
 func GetLevelDBMinorVersion() int {
 	return int(C.leveldb_minor_version())
 }


### PR DESCRIPTION
Mostly documentation changes, but 5f86cea would allow the library (and by extension, DVID's `basholeveldb` tag) to be built natively on Windows, using MinGW. I've left out all the commits related to Travis and GitHub Actions though, not sure whether they make sense in a fork?

This would raise the minimum LevelDB version to 1.7, but as far as I can tell, the [flyem-forge conda package already uses 1.9](https://anaconda.org/flyem-forge/basholeveldb), so it should be fine?